### PR TITLE
Permanently delete page revisions and leftovers

### DIFF
--- a/includes/SpecialNuke.php
+++ b/includes/SpecialNuke.php
@@ -1,7 +1,172 @@
 <?php
 
 class SpecialNuke extends SpecialPage {
+    // Code imported from DeletePagesForGood extension (https://github.com/wikimedia/mediawiki-extensions-DeletePagesForGood)
+    public function deletePermanently( Title $title ) {
+		$ns = $title->getNamespace();
+		$t = $title->getDBkey();
+		$id = $title->getArticleID();
+		$cats = $title->getParentCategories();
 
+		$dbw = wfGetDB( DB_MASTER );
+
+		$dbw->startAtomic( __METHOD__ );
+
+		/*
+		 * First delete entries, which are in direct relation with the page:
+		 */
+
+		# delete redirect...
+		$dbw->delete( 'redirect', [ 'rd_from' => $id ], __METHOD__ );
+
+		# delete external link...
+		$dbw->delete( 'externallinks', [ 'el_from' => $id ], __METHOD__ );
+
+		# delete language link...
+		$dbw->delete( 'langlinks', [ 'll_from' => $id ], __METHOD__ );
+
+		if ( !$GLOBALS['wgDBtype'] == "postgres" ) {
+			# delete search index...
+			$dbw->delete( 'searchindex', [ 'si_page' => $id ], __METHOD__ );
+		}
+
+		# Delete restrictions for the page
+		$dbw->delete( 'page_restrictions', [ 'pr_page' => $id ], __METHOD__ );
+
+		# Delete page Links
+		$dbw->delete( 'pagelinks', [ 'pl_from' => $id ], __METHOD__ );
+
+		# delete category links
+		$dbw->delete( 'categorylinks', [ 'cl_from' => $id ], __METHOD__ );
+
+		# delete template links
+		$dbw->delete( 'templatelinks', [ 'tl_from' => $id ], __METHOD__ );
+
+		# read text entries for all revisions and delete them.
+		$res = $dbw->select( 'revision', 'rev_text_id', "rev_page=$id" );
+
+		foreach ( $res as $row ) {
+			$value = $row->rev_text_id;
+			$dbw->delete( 'text', [ 'old_id' => $value ], __METHOD__ );
+		}
+
+		# In the table 'revision' : Delete all the revision of the page where 'rev_page' = $id
+		$dbw->delete( 'revision', [ 'rev_page' => $id ], __METHOD__ );
+
+		# delete image links
+		$dbw->delete( 'imagelinks', [ 'il_from' => $id ], __METHOD__ );
+
+		/*
+		 * then delete entries which are not in direct relation with the page:
+		 */
+
+		# Clean up recentchanges entries...
+		$dbw->delete( 'recentchanges', [
+			'rc_namespace' => $ns,
+			'rc_title' => $t
+		], __METHOD__ );
+
+		# read text entries for all archived pages and delete them.
+		$res = $dbw->select( 'archive', 'ar_text_id', [
+			'ar_namespace' => $ns,
+			'ar_title' => $t
+		] );
+
+		foreach ( $res as $row ) {
+			$value = $row->ar_text_id;
+			$dbw->delete( 'text', [ 'old_id' => $value ], __METHOD__ );
+		}
+
+		# Clean archive entries...
+		$dbw->delete( 'archive', [
+			'ar_namespace' => $ns,
+			'ar_title' => $t
+		], __METHOD__ );
+
+		# Clean up log entries...
+		$dbw->delete( 'logging', [
+			'log_namespace' => $ns,
+			'log_title' => $t
+		], __METHOD__ );
+
+		# Clean up watchlist...
+		$dbw->delete( 'watchlist', [
+			'wl_namespace' => $ns,
+			'wl_title' => $t
+		], __METHOD__ );
+
+		# In the table 'page' : Delete the page entry
+		$dbw->delete( 'page', [ 'page_id' => $id ], __METHOD__ );
+
+		/*
+		 * If the article belongs to a category, update category counts
+		 */
+		if ( !empty( $cats ) ) {
+			foreach ( $cats as $parentcat => $currentarticle ) {
+				$catname = preg_split( '/:/', $parentcat, 2 );
+				$cat = Category::newFromName( $catname[1] );
+				if ( !is_object( $cat ) ) {
+					// Blank error to allow us to continue
+				} else {
+					$cat->refreshCounts();
+				}
+			}
+		}
+
+		/*
+		 * If an image is beeing deleted, some extra work needs to be done
+		 */
+		if ( $ns == NS_FILE ) {
+			$file = wfFindFile( $t );
+
+			if ( $file ) {
+				# Get all filenames of old versions:
+				$fields = OldLocalFile::selectFields();
+				$res = $dbw->select( 'oldimage', $fields, [ 'oi_name' => $t ] );
+
+				foreach ( $res as $row ) {
+					$oldLocalFile = OldLocalFile::newFromRow( $row, $file->repo );
+					$path = $oldLocalFile->getArchivePath() . '/' . $oldLocalFile->getArchiveName();
+
+					try {
+						unlink( $path );
+					}
+					catch ( Exception $e ) {
+						return $e->getMessage();
+					}
+				}
+
+				$path = $file->getLocalRefPath();
+
+				try {
+					$file->purgeThumbnails();
+					unlink( $path );
+				} catch ( Exception $e ) {
+					return $e->getMessage();
+				}
+			}
+
+			# clean the filearchive for the given filename:
+			$dbw->delete( 'filearchive', [ 'fa_name' => $t ], __METHOD__ );
+
+			# Delete old db entries of the image:
+			$dbw->delete( 'oldimage', [ 'oi_name' => $t ], __METHOD__ );
+
+			# Delete archive entries of the image:
+			$dbw->delete( 'filearchive', [ 'fa_name' => $t ], __METHOD__ );
+
+			# Delete image entry:
+			$dbw->delete( 'image', [ 'img_name' => $t ], __METHOD__ );
+
+			// $dbw->endAtomic( __METHOD__ );
+
+			$linkCache = LinkCache::singleton();
+			$linkCache->clear();
+		}
+		$dbw->endAtomic( __METHOD__ );
+		return true;
+	}
+	
 	public function __construct() {
 		parent::__construct( 'Nuke', 'nuke' );
 	}
@@ -360,6 +525,8 @@ class SpecialNuke extends SpecialPage {
 			} else {
 				$res[] = $this->msg( 'nuke-not-deleted', $title->getPrefixedText() )->parse();
 			}
+			
+			$this->deletePermanently($title);
 		}
 
 		$this->getOutput()->addHTML( "<ul>\n<li>" . implode( "</li>\n<li>", $res ) . "</li>\n</ul>\n" );


### PR DESCRIPTION
Please consider adding the following additions in order to allow a full deletion of 'to-nuke' pages and its leftovers (such as revisions, logs, cache, etc..) from the database.

To note, that the code is not perfect and is as a form of a workaround to a missing feature that is extremely useful in fighting the on-going war on spam, so please refactor and improve at will.

This commit includes code imported from DeletePagesForGood extension (https://github.com/wikimedia/mediawiki-extensions-DeletePagesForGood)